### PR TITLE
fix(logs): avoid GH "{workflow} / {job} {step}" prefix on each log-line

### DIFF
--- a/lua/guh/gh.lua
+++ b/lua/guh/gh.lua
@@ -404,16 +404,19 @@ function M.get_pr_ci_logs(job_id, cb)
   local progress = util.new_progress_report('Loading CI log', 0)
   progress('running', nil, 'job %s', tostring(job_id))
 
-  util.system({ 'gh', 'run', 'view', '--job', tostring(job_id), '--log' },
-    function(logs, stderr, code)
-      if code ~= 0 or util.is_empty(vim.trim(logs or '')) then
-        progress('failed')
-        cb(nil, ('Log unavailable: %s'):format(vim.trim(stderr or '')))
-        return
-      end
-      progress('success')
-      cb(vim.trim(logs))
-    end)
+  -- Use the raw REST endpoint instead of `gh run view --log` to avoid gh's "{workflow} / {job} {step}" prefix.
+  util.system({
+    'gh', 'api',
+    f('repos/{owner}/{repo}/actions/jobs/%s/logs', tostring(job_id)),
+  }, function(logs, stderr, code)
+    if code ~= 0 or util.is_empty(vim.trim(logs or '')) then
+      progress('failed')
+      cb(nil, ('Log unavailable: %s'):format(vim.trim(stderr or '')))
+      return
+    end
+    progress('success')
+    cb(vim.trim(logs))
+  end)
 end
 
 M.get_repo_async = async.wrap(1, M.get_repo)


### PR DESCRIPTION
Problem:
The logs look like this:

    windows / windows (functional)UNKNOWN STEP2026-05-25T01:35:35.0565679Z Current runner version: '2.334.0'
    windows / windows (functional)UNKNOWN STEP2026-05-25T01:35:35.0598549Z ##[group]Runner Image Provisioner
    windows / windows (functional)UNKNOWN STEP2026-05-25T01:35:35.0599604Z Hosted Compute Agent
    windows / windows (functional)UNKNOWN STEP2026-05-25T01:35:35.0600365Z Version: 20260213.493
    windows / windows (functional)UNKNOWN STEP2026-05-25T01:35:35.0601170Z Commit:

Solution:
Use `gh api` instead of `gh run view`.

    2026-05-25T01:35:35.2997019Z Current runner version: '2.334.0'
    2026-05-25T01:35:35.3020257Z ##[group]Runner Image Provisioner
    2026-05-25T01:35:35.3021169Z Hosted Compute Agent
    2026-05-25T01:35:35.3021829Z Version: 20260213.493
    2026-05-25T01:35:35.3022897Z Commit: 5c115507f6dd24b8de37d8bbe0bb4509d0cc0fa3