### PR TITLE
fix(ui): use virt_lines for overlay text

### DIFF
--- a/lua/guh/comments.lua
+++ b/lua/guh/comments.lua
@@ -467,11 +467,7 @@ function M.edit_comment(feat, prnum, content, infomsg, callback)
     vim.cmd [[set wrap breakindent nonumber norelativenumber nolist]]
   end)
 
-  local ns = vim.api.nvim_create_namespace('guh.edit_comment.hint')
-  vim.api.nvim_buf_set_extmark(buf, ns, 0, 0, {
-    virt_lines_above = true,
-    virt_lines = { { { infomsg or 'Edit, then :wq to post (:q! to abort).', 'Comment' } } },
-  })
+  util.show_info_overlay(buf, infomsg or 'Edit, then :wq to post (:q! to abort).')
 
   vim.bo[buf].buftype = 'acwrite'
   vim.bo[buf].filetype = 'markdown'
@@ -480,7 +476,7 @@ function M.edit_comment(feat, prnum, content, infomsg, callback)
 
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, content)
   vim.bo[buf].modified = false
-  vim.cmd [[normal! G]]
+  vim.cmd [[normal! gg]]
 
   local pending ---@type string?
   local group = vim.api.nvim_create_augroup('guh.edit_comment.' .. buf, { clear = true })

--- a/lua/guh/util.lua
+++ b/lua/guh/util.lua
@@ -225,48 +225,25 @@ function M.run_term_cmd(buf, feat, id, cmd, on_done)
   end)
 end
 
-local overlay_win = -1
-local overlay_buf = -1
+local overlay_ns = vim.api.nvim_create_namespace('guh.info_overlay')
 
---- Shows an info overlay message in the given buffer.
---- Only one overlay is allowed globally.
---- Pass `msg=nil` to delete the current overlay.
+--- Shows an info overlay message above line 1 of the given buffer.
+--- Renders as a virtual line (extmark), so it scrolls with content and
+--- never covers buffer text. Pass `msg=nil` to clear.
 ---
 --- @param buf integer
---- @param msg string? Message, or nil to delete the current overlay.
+--- @param msg string? Message, or nil to clear the overlay.
 function M.show_info_overlay(buf, msg)
-  local win = (vim.fn.win_findbuf(buf) or {})[1]
-  local winvalid = vim.api.nvim_win_is_valid
-  if not win then
-    return -- Buffer not currently visible in any window.
+  if not vim.api.nvim_buf_is_valid(buf) then
+    return
   end
-  -- vim.api.nvim_buf_clear_namespace(buf, overlay_ns, 0, -1)
-  if not msg then
-    if winvalid(overlay_win) then
-      vim.api.nvim_win_close(overlay_win, true)
-    end
-    return -- If msg=nil, only clear the overlay.
+  vim.api.nvim_buf_clear_namespace(buf, overlay_ns, 0, -1)
+  if msg then
+    vim.api.nvim_buf_set_extmark(buf, overlay_ns, 0, 0, {
+      virt_lines_above = true,
+      virt_lines = { { { msg, 'Comment' } } },
+    })
   end
-
-  -- Scratch buffer
-  overlay_buf = vim.api.nvim_buf_is_valid(overlay_buf) and overlay_buf or vim.api.nvim_create_buf(false, true)
-  vim.api.nvim_buf_set_lines(overlay_buf, 0, -1, false, { msg })
-
-  local winconfig = {
-    focusable = false,
-    hide = false,
-    relative = 'win', -- Anchor to window
-    win = win,
-    row = 0,
-    col = 2,
-    width = math.max(1, vim.api.nvim_win_get_width(win) - 2),
-    height = 1,
-    style = 'minimal',
-    border = 'none',
-  }
-  overlay_win = winvalid(overlay_win) and overlay_win or vim.api.nvim_open_win(overlay_buf, false, winconfig)
-  vim.api.nvim_win_set_config(overlay_win, winconfig)
-  vim.wo[overlay_win].winhighlight = 'Normal:Comment'
 end
 
 return M


### PR DESCRIPTION
Problem:
"overlay window" text may obscure the first line of text.

Solution:
Use the `virt_lines` feature instead of an overlay floatwin.