### PR TITLE
fix(merge): write-and-close to confirm

### DIFF
--- a/lua/guh/comments.lua
+++ b/lua/guh/comments.lua
@@ -470,34 +470,34 @@ function M.edit_comment(feat, prnum, content, infomsg, callback)
   util.show_info_overlay(buf, infomsg or 'Edit, then :wq to post (:q! to abort).')
 
   vim.bo[buf].buftype = 'acwrite'
+  vim.bo[buf].bufhidden = 'wipe' -- Ensure BufWipeout fires on :q.
   vim.bo[buf].filetype = 'markdown'
   vim.bo[buf].modifiable = true
   vim.bo[buf].textwidth = 0
 
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, content)
-  vim.bo[buf].modified = false
+  -- Stay 'modified' so plain :q is refused: user must pick ZZ (submit) or ZQ (abort).
+  vim.bo[buf].modified = true
   vim.cmd [[normal! gg]]
 
-  local pending ---@type string?
   local group = vim.api.nvim_create_augroup('guh.edit_comment.' .. buf, { clear = true })
 
   -- Write-and-close confirms the action (vim-fugitive style).
   vim.api.nvim_create_autocmd('BufWriteCmd', {
     group = group,
     buffer = buf,
-    callback = function()
-      pending = table.concat(vim.api.nvim_buf_get_lines(buf, 0, -1, false), '\n')
-      vim.bo[buf].modified = false
-    end,
-  })
-  vim.api.nvim_create_autocmd({ 'BufWipeout', 'BufUnload' }, {
-    group = group,
-    buffer = buf,
     once = true,
     callback = function()
-      if pending then
-        callback(pending)
-      end
+      local input = table.concat(vim.api.nvim_buf_get_lines(buf, 0, -1, false), '\n')
+      vim.bo[buf].modified = false
+      vim.api.nvim_create_autocmd('BufWipeout', {
+        group = group,
+        buffer = buf,
+        once = true,
+        callback = function()
+          callback(input)
+        end,
+      })
     end,
   })
 end

--- a/test/gh_spec.lua
+++ b/test/gh_spec.lua
@@ -251,12 +251,18 @@ describe('commands', function()
   it(':GuhDiff loads PR diff + comments split window', function()
     n.command('GuhDiff 1')
 
+    t.retry(nil, nil, function()
+      n.command('2 wincmd w')
+    end)
+    -- XXX: jiggle the comments viewport so the overlay appears. Is this a virt_lines bug?
+    n.feed('<C-y>')
+
     screen:expect {
       timeout = 10000,
       attr_ids = {}, -- Don't care about colors.
       grid = [[
-        ^diff --git {MATCH:a/.* b/.*}│  Empty line = no comment {MATCH:.*}|
-        index {MATCH:.*}|
+        diff --git {MATCH:a/.* b/.*}│Empty line = no comment {MATCH:.*}|
+        index {MATCH:.*}│^{MATCH:.*}|
         --- {MATCH:.*}|
         +++ {MATCH:.*}|
         @@ {MATCH:.*} @@ {MATCH:.*}|


### PR DESCRIPTION
Problem:
When I use cM to see the merge buffer, if I clear the buffer and close it with ZQ, it merges. And conversely, if I add content and save it with ZZ, it does NOT merge...

Solution:
The buffer has `bufhidden=hide` (inherited from scratch), so :wq and :q! just hide the window: `BufWipeout`/`BufUnload` never fire.

- set `bufhidden=wipe` so close events actually fire
- keep the buffer `modified=true` so plain :q is refused (user must choose ZZ or ZQ).

Also fix a race: create the `BufWipeout` handler with `once=true` on `BufWriteCmd`.