### PR TITLE
fix(merge): commit message contains CR chars

### DIFF
--- a/lua/guh/pr_commands.lua
+++ b/lua/guh/pr_commands.lua
@@ -123,7 +123,8 @@ function M.merge_pr()
         return util.msg(('PR #%s not found'):format(id), vim.log.levels.ERROR)
       end
       vim.schedule(function()
-        local content = vim.split(('%s\n\n%s'):format(pr.title or '', pr.body or ''), '\n', { plain = true })
+        local text = ('%s\n\n%s'):format(pr.title or '', pr.body or ''):gsub('\r', '')
+        local content = vim.split(text, '\n', { plain = true })
         local infomsg = 'First line = subject; rest = body. :wq to merge (:q! to abort).'
         comments.edit_comment('merge', id, content, infomsg, function(input)
           local subject, body = input:match('^([^\n]*)\n?(.*)$')


### PR DESCRIPTION
Problem:
The merge edit buffer shows ^M chars in Nvim, probably because the CRLF
"body" is appended to a LF subject.

Solution:
Trim the CR chars.
