### PR TITLE
fix(merge): abort if commit-msg buffer is empty

### DIFF
--- a/doc/guh.txt
+++ b/doc/guh.txt
@@ -115,7 +115,7 @@ Comment on issues, PRs, and diffs                                *guh-comment*
 
 Opens an editable `guh://comment/<N>` buffer. To submit:
 - `:wq` (or `ZZ`) posts the comment.
-- `:q!` discards.
+- `:q!` (or `ZQ`) discards. Also if buffer is empty.
 
 :GuhComment   With bang "!", comments on PR at top level. Without bang,
               comments on the current diff line or range. >
@@ -128,8 +128,8 @@ Merging PRs                                                        *guh-merge*
 `cM` on a PR view opens a method picker ("squash"/"merge"/"rebase"). For
 "squash" and "merge" a `guh://merge/<id>` buffer opens, prefilled with the PR
 title and body. To confirm and merge the PR:
-- `:wq`  the commit (first line = `--subject`, rest = `--body`).
-- `:q!` aborts the merge.
+- `:wq` (or `ZZ`) merges (first line = `--subject`, rest = `--body`).
+- `:q!` (or `ZQ`) aborts. Also if buffer is empty.
 
 
 ------------------------------------------------------------------------------

--- a/lua/guh/comments.lua
+++ b/lua/guh/comments.lua
@@ -457,8 +457,8 @@ end
 --- @param prnum integer
 --- @param content string[] lines to prefill the buffer with
 --- @param infomsg? string overlay message; nil = default
---- @param callback fun(input: string) called only on save-then-close
-function M.edit_comment(feat, prnum, content, infomsg, callback)
+--- @param cb fun(input: string) called only on save-then-close
+function M.edit_comment(feat, prnum, content, infomsg, cb)
   if not state.try_show(feat, prnum) then
     vim.cmd [[split]]
   end
@@ -495,7 +495,11 @@ function M.edit_comment(feat, prnum, content, infomsg, callback)
         buffer = buf,
         once = true,
         callback = function()
-          callback(input)
+          if vim.trim(input) ~= '' then
+            cb(input)
+          else
+            util.msg('aborted (empty buffer)')
+          end
         end,
       })
     end,


### PR DESCRIPTION
Problem:
Writing an empty/whitespace-only commit message can trigger the merge.

Solution:
Skip the action if the content is empty.
