### PR TITLE
fix(util): disable pagers in terminal jobs

### DIFF
--- a/lua/guh/util.lua
+++ b/lua/guh/util.lua
@@ -255,6 +255,10 @@ function M.run_term_cmd(buf, feat, id, cmd, on_done)
     vim.o.modified = false
     vim.fn.jobstart(cmd, {
       term = true,
+      env = {
+        GH_PAGER = 'cat',
+        PAGER = 'cat',
+      },
       on_exit = function()
         local ns = vim.api.nvim_get_namespaces()['nvim.terminal.exitmsg']
         if ns and vim.api.nvim_buf_is_valid(buf) then


### PR DESCRIPTION
Set GH_PAGER and PAGER to 'cat' when launching terminal jobs via vim.fn.jobstart. This prevents git/gh from invoking interactive pagers (like less) that can block output or require input in a non-interactive terminal buffer, ensuring command output is emitted directly to the buffer.