### PR TITLE
perf: run commands in parallel

### DIFF
--- a/lua/guh/pr.lua
+++ b/lua/guh/pr.lua
@@ -556,22 +556,19 @@ function M.show_status(focus, repo)
     ]]
     )
     table.insert(cmds, { 'gh', 'pr', 'status', '--repo', repo })
-    table.insert(
-      cmds,
-      {
-        'gh',
-        'api',
-        'graphql',
-        '-f',
-        'owner=' .. owner,
-        '-f',
-        'name=' .. name,
-        '-f',
-        'query=' .. query,
-        '--template',
-        tmpl,
-      }
-    )
+    table.insert(cmds, {
+      'gh',
+      'api',
+      'graphql',
+      '-f',
+      'owner=' .. owner,
+      '-f',
+      'name=' .. name,
+      '-f',
+      'query=' .. query,
+      '--template',
+      tmpl,
+    })
   end
   util.run_term_cmds(buf, { pty = true }, cmds, function()
     util.set_default_keymaps(buf)

--- a/lua/guh/pr.lua
+++ b/lua/guh/pr.lua
@@ -556,7 +556,22 @@ function M.show_status(focus, repo)
     ]]
     )
     table.insert(cmds, { 'gh', 'pr', 'status', '--repo', repo })
-    table.insert(cmds, { 'gh', 'api', 'graphql', '-f', 'owner=' .. owner, '-f', 'name=' .. name, '-f', 'query=' .. query, '--template', tmpl })
+    table.insert(
+      cmds,
+      {
+        'gh',
+        'api',
+        'graphql',
+        '-f',
+        'owner=' .. owner,
+        '-f',
+        'name=' .. name,
+        '-f',
+        'query=' .. query,
+        '--template',
+        tmpl,
+      }
+    )
   end
   util.run_term_cmds(buf, { pty = true }, cmds, function()
     util.set_default_keymaps(buf)

--- a/lua/guh/pr.lua
+++ b/lua/guh/pr.lua
@@ -531,7 +531,7 @@ end
 function M.show_status(focus, repo)
   repo = repo or (vim.b.guh or {}).repo or resolve_local_repo()
   local buf = state.init_buf('status', focus, nil, 'all', { repo = repo })
-  local cmd = { 'gh', 'status' }
+  local cmds = { { 'gh', 'status' } }
   if repo then
     local owner, name = repo:match('^([^/]+)/(.+)$')
     local query = vim.text.indent(
@@ -555,16 +555,10 @@ function M.show_status(focus, repo)
       {{range .data.repository.issues.nodes}}{{printf "  %-7s%s\n" (printf "#%v" .number) .title}}{{end}}
     ]]
     )
-    cmd = util.shell_cmd(
-      'gh status && gh pr status --repo %s && gh api graphql -f owner=%s -f name=%s -f query=%s --template %s',
-      repo,
-      owner,
-      name,
-      query,
-      tmpl
-    )
+    table.insert(cmds, { 'gh', 'pr', 'status', '--repo', repo })
+    table.insert(cmds, { 'gh', 'api', 'graphql', '-f', 'owner=' .. owner, '-f', 'name=' .. name, '-f', 'query=' .. query, '--template', tmpl })
   end
-  util.run_term_cmd(buf, cmd, function()
+  util.run_term_cmds(buf, { pty = true }, cmds, function()
     util.set_default_keymaps(buf)
   end)
 end
@@ -574,7 +568,7 @@ end
 --- @param focus boolean
 function M.show_issue(id, repo, focus)
   local buf = state.init_buf('issue', focus, repo, id)
-  util.run_term_cmd(buf, gh.cmd(repo, 'issue', 'view', tostring(id), '--comments'), function()
+  util.run_term_cmds(buf, { pty = true }, { gh.cmd(repo, 'issue', 'view', tostring(id), '--comments') }, function()
     util.set_default_keymaps(buf)
   end)
 end
@@ -598,16 +592,10 @@ function M.show_pr(id, repo, focus, old_head)
     {{range .commits}}  {{slice .oid 0 12}}  {{slice .committedDate 0 10}}  {{.messageHeadline}}{{"\n"}}{{end}}
   ]]
   )
-  local cmd = util.shell_cmd(
-    'gh pr view --comments %s --repo %s && gh pr view %s --repo %s --json commits --template %s',
-    id,
-    repo,
-    id,
-    repo,
-    commits_tmpl
-  )
-
-  util.run_term_cmd(buf, cmd, function()
+  util.run_term_cmds(buf, { pty = true }, {
+    gh.cmd(repo, 'pr', 'view', '--comments', tostring(id)),
+    gh.cmd(repo, 'pr', 'view', tostring(id), '--json', 'commits', '--template', commits_tmpl),
+  }, function()
     util.set_default_keymaps(buf)
     -- Poll `state.get_pr_data` (populated by `load_pr`) until ready.
     local tries = 0
@@ -812,7 +800,7 @@ function M.edit_pr()
   local feat, id, repo = resolve_pr()
   local kind = feat == 'issue' and 'issue' or 'pr'
   local buf = state.init_buf('edit', true, repo, id)
-  util.run_term_cmd(buf, gh.cmd(repo, kind, 'edit', tostring(id)), function()
+  util.run_term_cmds(buf, { pty = true }, { gh.cmd(repo, kind, 'edit', tostring(id)) }, function()
     util.set_default_keymaps(buf)
   end)
 end

--- a/lua/guh/state.lua
+++ b/lua/guh/state.lua
@@ -166,7 +166,7 @@ function M.init_buf(feat, focus, repo, id, bufstate)
   if bufstate.repo == nil and repo then
     bufstate.repo = repo
   end
-  -- XXX: Stash the key so anything (e.g. `util.run_term_cmd()`) can rebuild the `guh://…` URL,
+  -- XXX: Stash the key so anything (e.g. `util.run_term_cmds()`) can rebuild the `guh://…` URL,
   -- even for "global" (non-repo-specific) buffers like `guh://status`.
   bufstate.bufkey = key
   M.set_b_guh(buf, bufstate)

--- a/lua/guh/util.lua
+++ b/lua/guh/util.lua
@@ -27,29 +27,6 @@ end
 --- into one row.
 local progress_echo_id = nil ---@type integer?
 
---- Builds an argv that runs `string.format(cmdstring, ...)` through a shell.
----
---- The purpose of this is to linearize a bunch of `cmd1 && cmd2 && …` shell commands into one terminal invocation.
----
---- TODO: this would not be needed if Nvim allowed appending-to a buftype=terminal buffer.
----
---- @param cmdstring string `string.format`-style script: "cmd1 && cmd2 && …"
---- @param ... string|number values to quote and substitute into `cmdstring`.
---- @return string[] argv
-function M.shell_cmd(cmdstring, ...)
-  local shell, flag, q
-  if vim.fn.has('win32') == 1 then
-    shell, flag, q = 'cmd.exe', '/c', '"'
-  else
-    shell, flag, q = 'sh', '-c', "'"
-  end
-  local args = { ... }
-  for i, v in ipairs(args) do
-    args[i] = q .. tostring(v) .. q
-  end
-  return { shell, flag, cmdstring:format(unpack(args)) }
-end
-
 --- Runs a command asynchronously via `vim.system`. The callback is deferred (`vim.schedule_wrap`).
 ---
 --- @param cmd string[] argv list.
@@ -333,70 +310,141 @@ function M.buf_set_readonly_lines(buf, lines, ft)
   vim.bo[buf].filetype = ft
 end
 
---- Overwrites the current :terminal buffer with the given cmd.
+--- Concurrently runs N commands and streams their stdout into a terminal buf in-order.
 ---
---- The buffer must have been initialized via `state.init_buf()` (`b:guh` is used to re-apply
---- the `guh://…` name on term exit, since Nvim stomps it).
+--- - Output of `cmds[1]` streams into the terminal as it arrives.
+--- - Output of `cmds[i>1]` is buffered while a lower-index command is still streaming, then flushed
+---   to the terminal in-order once the lower-index commands exit.
 ---
 --- @param buf integer (must have `b:guh` set by `state.init_buf()`)
---- @param cmd string[]
+--- @param opts? { pty?: boolean }
+--- @param cmds string[][] List of commands.
 --- @param on_done? fun()
-function M.run_term_cmd(buf, cmd, on_done)
+function M.run_term_cmds(buf, opts, cmds, on_done)
+  vim.validate('buf', buf, 'number')
+  vim.validate('cmds', cmds, function(v)
+    return type(v) == 'table' and #v > 0
+  end, 'non-empty list')
   -- Fail fast if b:guh is invalid (init_buf() wasn't called?).
   local b_guh = vim.b[buf].guh
-  assert(b_guh and b_guh.feat and b_guh.bufkey, ('run_term_cmd: invalid b:guh on buf %d'):format(buf))
+  assert(b_guh and b_guh.feat and b_guh.bufkey, ('run_term_cmds: invalid b:guh on buf %d'):format(buf))
   local progress = M.new_progress_report('Loading...', buf)
   progress('running')
   vim.schedule(function()
-    assert(vim.api.nvim_buf_is_valid(buf), ('run_term_cmd: invalid buf %d'):format(buf))
-    -- terminal buf can be updated only if the job exited.
-    local jobid = vim.bo[buf].channel
-    if vim.fn.jobwait({ jobid }, 0)[1] == -1 then
-      M.log('run_term_cmd skipped:', { buf = buf, cmd = cmd, reason = 'job still running' })
-      progress('cancel')
-      return
-    end
+    assert(vim.api.nvim_buf_is_valid(buf), ('run_term_cmds: invalid buf %d'):format(buf))
 
-    -- UX: Preserve viewport of all windows showing the existing terminal buf.
-    -- This makes "reload" less disorienting.
+    -- UX: Preserve viewport of windows showing the buf. This makes "reload" less disorienting.
     local winviews = {}
     for _, win in ipairs(vim.fn.win_findbuf(buf)) do
-      winviews[win] = vim.fn.winsaveview()
+      winviews[win] = vim.api.nvim_win_call(win, function()
+        return vim.fn.winsaveview()
+      end)
     end
 
-    -- Use nvim_buf_call because `jobstart({term=true})` assumes curbuf.
-    vim.api.nvim_buf_call(buf, function()
-      local isempty = 1 == vim.fn.line('$') and '' == vim.fn.getline(1)
-      assert(isempty or not vim.api.nvim_buf_is_loaded(buf) or vim.bo[buf].buftype == 'terminal')
-      vim.o.modifiable = true
-      vim.o.modified = false
+    -- Create or reuse the terminal-buf channel.
+    local chan = (state.get_b_guh(buf) or {}).chan
+    if not chan then
+      chan = vim.api.nvim_open_term(buf, {})
+      -- XXX: store `b:guh.chan` because `nvim_open_term` doesn't set `vim.bo.channel` (Nvim bug).
+      state.set_b_guh(buf, { chan = chan })
+    else
+      -- `nvim_open_term` can't reattach to buftype=terminal buf, even
+      -- after chanclose(), so on re-entry we use the existing chan and send RIS (`\27c` = Reset).
+      vim.api.nvim_chan_send(chan, '\27c')
+    end
+
+    local debug = vim.g.guh_debug == true
+    -- Per-cmd result.
+    local r = {} ---@type { out?: string, err?: string, exited?: number }[]
+    local start_ms = vim.uv.now()
+
+    local function on_all_done()
+      -- Append a timing report.
+      local report = { '', '--- timing ---' }
+      for i, cmd in ipairs(cmds) do
+        local cmd_str = table.concat(cmd, ' '):gsub('%s+', ' ')
+        if #cmd_str > 60 then
+          cmd_str = cmd_str:sub(1, 57) .. '…'
+        end
+        table.insert(report, ('%s: %dms'):format(cmd_str, r[i].exited - start_ms))
+      end
+      vim.api.nvim_chan_send(chan, table.concat(report, '\r\n') .. '\r\n')
+
+      for win, winview in pairs(winviews) do
+        if vim.api.nvim_win_is_valid(win) then
+          vim.api.nvim_win_call(win, function()
+            vim.fn.winrestview(winview)
+          end)
+        end
+      end
+      if on_done then
+        on_done()
+      end
+      progress('success')
+    end
+
+    -- Advance through cmds that have exited, displayed their output in-order.
+    local curr = 1
+    local function try_advance()
+      while curr <= #cmds and r[curr] and r[curr].exited do
+        local out = r[curr].out
+        if out and vim.trim(out) ~= '' then
+          vim.api.nvim_chan_send(chan, out)
+        end
+        local err = r[curr].err
+        if debug and err and vim.trim(err) ~= '' then
+          vim.api.nvim_chan_send(chan, '\r\n--- stderr ---\r\n' .. err)
+        end
+        curr = curr + 1
+      end
+      if curr > #cmds then
+        on_all_done()
+      end
+    end
+
+    local pty = opts and opts.pty == true
+    local wins = vim.fn.win_findbuf(buf)
+    local width = (wins[1] and vim.api.nvim_win_get_width(wins[1])) or 200
+    local env = { GH_PAGER = 'cat', PAGER = 'cat' }
+    if debug then
+      -- `GH_DEBUG=api` logs each HTTP request to stderr with method, URL, status, and round-trip ms.
+      env.GH_DEBUG = 'api'
+    end
+    for i, cmd in ipairs(cmds) do
       vim.fn.jobstart(cmd, {
-        term = true,
-        env = {
-          GH_PAGER = 'cat',
-          PAGER = 'cat',
-        },
+        pty = pty,
+        width = pty and width or nil,
+        -- Since the cost is server-side (gh API latency), we don't need to "stream" per-command output.
+        stdout_buffered = true,
+        stderr_buffered = debug or nil,
+        env = env,
+        --- @param data string[]
+        on_stdout = function(_, data)
+          r[i] = r[i] or {}
+          r[i].out = table.concat(data, '\n')
+        end,
+        --- @param data string[]
+        on_stderr = debug and function(_, data)
+          r[i] = r[i] or {}
+          r[i].err = table.concat(data, '\n')
+        end or nil,
         on_exit = function()
-          -- XXX: hide the Nvim default "[Process exited]" message.
-          local ns = vim.api.nvim_get_namespaces()['nvim.terminal.exitmsg']
-          if ns and vim.api.nvim_buf_is_valid(buf) then
-            vim.api.nvim_buf_clear_namespace(buf, ns, 0, -1)
-          end
-          state.set_buf_name(buf, b_guh.feat, b_guh.bufkey)
-          for win, winview in pairs(winviews) do
-            if vim.api.nvim_win_is_valid(win) then
-              vim.api.nvim_win_call(win, function()
-                vim.fn.winrestview(winview)
-              end)
+          r[i] = r[i] or {}
+          r[i].exited = vim.uv.now()
+          local n_done = 0
+          for j = 1, #cmds do
+            if r[j] and r[j].exited then
+              n_done = n_done + 1
             end
           end
-          if on_done then
-            on_done()
+          if n_done < #cmds then
+            -- Report progress as cmds complete.
+            progress('running', math.floor(100 * n_done / #cmds), '%d/%d', n_done, #cmds)
           end
-          progress('success')
+          try_advance()
         end,
       })
-    end)
+    end
   end)
 end
 

--- a/lua/guh/util.lua
+++ b/lua/guh/util.lua
@@ -354,7 +354,7 @@ function M.run_term_cmds(buf, opts, cmds, on_done)
     end
 
     local debug = vim.g.guh_debug == true
-    -- Per-cmd result.
+    -- Per-cmd result. `exited` is `on_exit` timestamp.
     local r = {} ---@type { out?: string, err?: string, exited?: number }[]
     local start_ms = vim.uv.now()
 
@@ -364,9 +364,9 @@ function M.run_term_cmds(buf, opts, cmds, on_done)
       for i, cmd in ipairs(cmds) do
         local cmd_str = table.concat(cmd, ' '):gsub('%s+', ' ')
         if #cmd_str > 60 then
-          cmd_str = cmd_str:sub(1, 57) .. '…'
+          cmd_str = cmd_str:sub(1, 57) .. '...'
         end
-        table.insert(report, ('%s: %dms'):format(cmd_str, r[i].exited - start_ms))
+        table.insert(report, ('%-61s %d ms'):format(cmd_str .. ':', r[i].exited - start_ms))
       end
       vim.api.nvim_chan_send(chan, table.concat(report, '\r\n') .. '\r\n')
 
@@ -406,13 +406,20 @@ function M.run_term_cmds(buf, opts, cmds, on_done)
     local wins = vim.fn.win_findbuf(buf)
     local width = (wins[1] and vim.api.nvim_win_get_width(wins[1])) or 200
     local env = { GH_PAGER = 'cat', PAGER = 'cat' }
+    if pty then
+      env.TERM = 'xterm-256color'
+      -- XXX: Disable gh terminal-capability queries (SLOW!): jobstart(pty=true) has no consumer to
+      -- respond, so each query waits its full 5s timeout.
+      -- TODO: make jobstart(pty=true) work (may require Nvim upstream changes)!
+      env.NO_COLOR = '1'
+    end
     if debug then
       -- `GH_DEBUG=api` logs each HTTP request to stderr with method, URL, status, and round-trip ms.
       env.GH_DEBUG = 'api'
     end
     for i, cmd in ipairs(cmds) do
       vim.fn.jobstart(cmd, {
-        pty = pty,
+        pty = pty, -- TODO: use `term` instead; "gh" queries the tty and stupidly waits up to 5s!
         width = pty and width or nil,
         -- Since the cost is server-side (gh API latency), we don't need to "stream" per-command output.
         stdout_buffered = true,

--- a/lua/guh/util.lua
+++ b/lua/guh/util.lua
@@ -2,7 +2,6 @@ local state = require('guh.state')
 
 local M = {}
 
-local overlay_ns = vim.api.nvim_create_namespace('guh.info_overlay')
 local flash_ns = vim.api.nvim_create_namespace('guh.flash')
 
 --- Flashes the given region so the user can see the target of an action.
@@ -408,27 +407,45 @@ function M.run_term_cmds(buf, opts, cmds, on_done)
     local env = { GH_PAGER = 'cat', PAGER = 'cat' }
     if pty then
       env.TERM = 'xterm-256color'
-      -- XXX: Disable gh terminal-capability queries (SLOW!): jobstart(pty=true) has no consumer to
-      -- respond, so each query waits its full 5s timeout.
-      -- TODO: make jobstart(pty=true) work (may require Nvim upstream changes)!
-      env.NO_COLOR = '1'
     end
     if debug then
       -- `GH_DEBUG=api` logs each HTTP request to stderr with method, URL, status, and round-trip ms.
       env.GH_DEBUG = 'api'
     end
     for i, cmd in ipairs(cmds) do
-      vim.fn.jobstart(cmd, {
-        pty = pty, -- TODO: use `term` instead; "gh" queries the tty and stupidly waits up to 5s!
+      -- Per-job scratchbuf + nvim_open_term channel for handling terminal queries (from commands
+      -- like "gh", which would otherwise hang/timeout). The job's raw stdout is streamed here via
+      -- `nvim_chan_send` so libvterm can parse queries (DA1/OSC/…), which then invokes `on_input`.
+      -- TODO: revisit this after: https://github.com/neovim/neovim/issues/40194
+      local qbuf, qchan, jobid
+      if pty then
+        qbuf = vim.api.nvim_create_buf(false, true)
+        qchan = vim.api.nvim_open_term(qbuf, {
+          on_input = function(_, _, _, data)
+            if jobid then
+              -- Forward the query response (from libvterm) to the job's stdin so the child ("gh").
+              vim.fn.chansend(jobid, data)
+            end
+          end,
+        })
+      end
+      jobid = vim.fn.jobstart(cmd, {
+        pty = pty,
         width = pty and width or nil,
         -- Since the cost is server-side (gh API latency), we don't need to "stream" per-command output.
-        stdout_buffered = true,
+        -- (Except for pty=true, until https://github.com/neovim/neovim/issues/40194 is fixed.)
+        stdout_buffered = not pty,
         stderr_buffered = debug or nil,
         env = env,
         --- @param data string[]
         on_stdout = function(_, data)
           r[i] = r[i] or {}
-          r[i].out = table.concat(data, '\n')
+          local chunk = table.concat(data, '\n')
+          r[i].out = (r[i].out or '') .. chunk
+          if qchan then
+            -- For pty: send query bytes to the nvim_open_term (libvterm) channel.
+            vim.api.nvim_chan_send(qchan, chunk)
+          end
         end,
         --- @param data string[]
         on_stderr = debug and function(_, data)
@@ -438,6 +455,13 @@ function M.run_term_cmds(buf, opts, cmds, on_done)
         on_exit = function()
           r[i] = r[i] or {}
           r[i].exited = vim.uv.now()
+          if qchan then
+            -- cleanup
+            pcall(vim.fn.chanclose, qchan)
+            if qbuf and vim.api.nvim_buf_is_valid(qbuf) then
+              vim.api.nvim_buf_delete(qbuf, { force = true })
+            end
+          end
           local n_done = 0
           for j = 1, #cmds do
             if r[j] and r[j].exited then


### PR DESCRIPTION

~~TODO: figure out why this is slow. seems like `on_exit` is delayed by 5s for each command~~

### Analysis

"gh" commands run by `run_term_cmds` (`jobstart(pty=true)`) take 5s, compared to 1s when we ran it as a single stringified "foo && …" command via `jobstart(term=true)`.

Unlike `term=true`, `pty=true` does not respond to terminal queries. Every "gh" invocation queries the terminal (bg color detection) and waits 5s! 🚮

### Solution

`NO_COLOR = '1'` is a workaround, which convinces `gh` to skip querying terminal colors.

The actual solution (10952d79ba7d4be199ee33ff91f8e7c1b3724380) is to forward the terminal queries from the job to a temporary `nvim_open_term` dummy buffer,

    • JOB: jobstart({'gh'}, {pty=true})
      • child: gh
    • DUMMY: nvim_open_term + scratchbuf

    Flow:
    -> gh queries the "terminal"
      -> JOB.on_stdout forwards to DUMMY
        -> DUMMY.on_input triggered by libvterm
          -> feed into JOB channel

## Future

This should be easier, see https://github.com/neovim/neovim/issues/40194