### PR TITLE
feat(ui): define 'winbar' as a template

### DIFF
--- a/lua/guh/comments.lua
+++ b/lua/guh/comments.lua
@@ -166,10 +166,7 @@ end
 --- @param id integer PR number.
 --- @param repo string "owner/name"
 --- @param diff_buf integer prdiff buffer.
---- @param pr_data PullRequest
---- @param n_files integer
---- @param n_viewed_threads integer
-function M.show_pr_comments(id, repo, diff_buf, pr_data, n_files, n_viewed_threads)
+function M.show_pr_comments(id, repo, diff_buf)
   if not state.try_show('prcomments', repo, id) then
     -- TODO: should state.init_buf() handle this? maybe helpful for <mods> handling on :Guh too?
     vim.cmd [[botright vertical split]]
@@ -179,24 +176,9 @@ function M.show_pr_comments(id, repo, diff_buf, pr_data, n_files, n_viewed_threa
   vim.api.nvim_win_set_buf(vim.api.nvim_get_current_win(), buf)
   vim.cmd [[set wrap breakindent nonumber norelativenumber nolist]]
 
-  local visible_threads = pr_data.n_threads - pr_data.n_resolved - n_viewed_threads
-  local n_viewed = vim.tbl_count(pr_data.viewed or {})
   vim.cmd [[wincmd p]] -- Return to diff window.
   local diff_win = vim.fn.win_findbuf(diff_buf)[1]
   local comments_win = vim.fn.win_findbuf(buf)[1]
-  util.show_winbar(diff_win, {
-    { 'PR diff | ' },
-    { ('Files: %d ('):format(n_files, n_viewed) },
-    { 'Viewed', '@markup.italic' },
-    { (': %d) | '):format(n_viewed) },
-    { 'Unresolved', '@markup.italic' },
-    { (' threads: %d'):format(visible_threads) },
-  })
-  util.show_winbar(comments_win, {
-    { ('PR comments | Visible: %d | Unresolved in '):format(visible_threads) },
-    { 'Viewed', '@markup.italic' },
-    { (' files: %d'):format(n_viewed_threads) },
-  })
 
   -- Set scrollbind+cursorbind on both windows *after* writing the buffer content.
   vim.api.nvim_win_call(diff_win, function()
@@ -216,10 +198,8 @@ end
 --- @param diff_buf integer prdiff buffer (provides the diff text + receives diagnostics).
 --- @param pr_data PullRequest (provides `viewed`, `n_threads`, `n_resolved`).
 --- @param comments_list table<string, CommentThread[]>
---- @param n_files integer Count of all files in the HEAD diff.
---- @param n_viewed_threads integer Unresolved threads hidden in "Viewed" files.
 --- @return integer buf the prcomments buffer.
-function M.load_pr_comments(id, repo, diff_buf, pr_data, comments_list, n_files, n_viewed_threads)
+function M.load_pr_comments(id, repo, diff_buf, pr_data, comments_list)
   local viewed = pr_data.viewed or {}
   local diff_lines = vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false)
 
@@ -704,13 +684,12 @@ function M.update_comment(linenr)
   with_comment(linenr, 'Which comment?', function(c, prnum, repo, _)
     local content = vim.split(c.body or '', '\n', { plain = true })
     local same = gh.get_user() == c.user
-    local infomsg = same and { { ('Updating comment %d | ZZ to confirm (ZQ to abort)'):format(c.id) } }
+    local info = same and { title = ('Updating comment %d'):format(c.id) }
       or {
-        { 'Updating comment by ' },
-        { ('%s %d (not you)'):format(c.user or '?', c.id), 'ErrorMsg' },
-        { ' | ZZ to confirm (ZQ to abort)' },
+        title = ('Updating comment by %s %d (not you)'):format(c.user or '?', c.id),
+        title_hl = 'ErrorMsg',
       }
-    M.edit_comment('comment', prnum, content, infomsg, function(input)
+    M.edit_comment('comment', prnum, content, info, function(input)
       local progress = util.new_progress_report('Updating comment...', vim.api.nvim_get_current_buf())
       gh.update_comment(c.id, input, repo, function(resp)
         if resp['errors'] == nil then
@@ -835,9 +814,9 @@ end
 --- @param feat 'comment'|'merge'|'review' kind of edit; each has its own per-PR buffer.
 --- @param prnum integer
 --- @param content string[] lines to prefill the buffer with
---- @param infomsg? [string, string?][] Heading text + highlights; nil = default.
+--- @param info? { title?: string, title_hl?: string, hint?: string } Used for 'winbar'.
 --- @param on_confirm fun(input: string) Called on write-and-close (not on abort/cancel).
-function M.edit_comment(feat, prnum, content, infomsg, on_confirm)
+function M.edit_comment(feat, prnum, content, info, on_confirm)
   local repo = assert((vim.b.guh or {}).repo, 'edit_comment: not in a guh:// buffer (no b:guh.repo)')
   if not state.try_show(feat, repo, prnum) then
     vim.cmd [[split]]
@@ -847,7 +826,9 @@ function M.edit_comment(feat, prnum, content, infomsg, on_confirm)
     vim.cmd [[set wrap breakindent nonumber norelativenumber nolist]]
   end)
 
-  util.show_winbar(0, infomsg or { { 'Edit comment | ZZ to post (ZQ to abort)' } })
+  info = info or { title = 'Edit comment' }
+  state.set_b_key(buf, { 'guh', 'title' }, info.title or '')
+  state.set_b_key(buf, { 'guh', 'title_hl' }, info.title_hl or '')
 
   vim.bo[buf].buftype = 'acwrite'
   vim.bo[buf].bufhidden = 'wipe' -- Ensure BufWipeout fires on :q.

--- a/lua/guh/comments.lua
+++ b/lua/guh/comments.lua
@@ -683,12 +683,12 @@ function M.delete_comment(linenr)
       return
     end
     local progress = util.new_progress_report('Deleting comment...', buf)
-    gh.delete_comment(c.id, repo, function(resp)
-      if not resp or resp.errors == nil then
+    gh.delete_comment(c.id, repo, function(ok, err)
+      if ok then
         progress('success', nil, 'Comment deleted.')
         require('guh.pr').refresh({ feat = 'pr', id = prnum, repo = repo })
       else
-        progress('failed', nil, 'Failed to delete comment.')
+        progress('failed', nil, err or 'Failed to delete comment.')
       end
     end)
   end)

--- a/lua/guh/gh.lua
+++ b/lua/guh/gh.lua
@@ -549,10 +549,16 @@ function M.update_comment(comment_id, body, repo, cb)
   }, cb)
 end
 
+--- Deletes a PR review comment.
+---
 --- @param repo string "owner/repo"
-function M.delete_comment(comment_id, repo, cb)
+--- @param on_done fun(ok: boolean, err?: string)
+function M.delete_comment(comment_id, repo, on_done)
   vim.validate('repo', repo, 'string')
-  gh_api('delete_comment', 'DELETE', f('repos/%s/pulls/comments/%s', repo, comment_id), {}, cb)
+  -- Note: gh_api() checks `resp.errors`, but this endpoint returns an empty 204.
+  util.system({ 'gh', 'api', '--method', 'DELETE', f('repos/%s/pulls/comments/%s', repo, comment_id) }, nil, function(r)
+    on_done(r.code == 0, r.code ~= 0 and vim.trim(r.stderr or '') or nil)
+  end)
 end
 
 --- Resolves a review comment-thread.

--- a/lua/guh/gh.lua
+++ b/lua/guh/gh.lua
@@ -521,6 +521,8 @@ function M.new_comment(pr, body, path, start_line, line, side, repo, cb)
   }
   if start_line ~= line then
     table.insert(fields, { '-F', 'start_line=' .. start_line })
+    -- Multiline: `start_side` must match `side`.
+    table.insert(fields, { '-f', 'start_side=' .. (side or 'RIGHT') })
   end
   gh_api('new_comment', 'POST', f('repos/%s/pulls/%d/comments', repo, pr.number), fields, cb)
 end

--- a/lua/guh/gh.lua
+++ b/lua/guh/gh.lua
@@ -35,6 +35,17 @@ function M.pr_state_label(pr)
   return pr.isDraft and 'Draft' or (pr.state and (pr.state:sub(1, 1) .. pr.state:sub(2):lower()) or '?')
 end
 
+--- Status emoji for a CI job.
+--- @param job CIJob
+function M.ci_icon(job)
+  if not job.conclusion then
+    return '⏳' -- No `conclusion` until job finishes (still-running / in-progress).
+  elseif job.conclusion == 'success' or job.conclusion == 'neutral' or job.conclusion == 'skipped' then
+    return '✅'
+  end
+  return '❌'
+end
+
 --- Gets the github.com web URL for a `guh://` buffer, or nil.
 ---
 --- @param buf integer Buffer id (0 for current buffer).

--- a/lua/guh/pr.lua
+++ b/lua/guh/pr.lua
@@ -102,52 +102,6 @@ local function require_pr(opts)
   return resolve_pr(opts, false)
 end
 
---- Returns an "Unread" 'winbar' chunk if the slug is in the `b:guh.notifications` map.
----
---- @param repo string "owner/name"
---- @param id integer|string
---- @return [string, string?]?
-local function notif_chunk(repo, id)
-  local status_buf = state.get_buf('status', nil, 'all', false)
-  local notif = status_buf and state.get_b_key(status_buf, { 'guh', 'notifications', ('%s#%s'):format(repo, id) })
-  return notif and { 'Unread', 'WarningMsg' } or nil
-end
-
---- Sets the 'winbar' for a pr/issue/repo/status view, in every window displaying `buf`.
----
---- @param buf integer
---- @param feat Feat
---- @param id any
---- @param repo? string
---- @param pr? PullRequest
-local function set_winbar(buf, feat, id, repo, pr)
-  local wins = vim.fn.win_findbuf(buf)
-  if #wins == 0 then
-    return
-  end
-  local st = pr and gh.pr_state_label(pr) or ''
-  local chunks = {
-    { ('%s %s%s '):format(feat:upper(), (feat == 'pr' or feat == 'issue') and '#' or '', id) },
-    { st, gh.state_hl[st] },
-  }
-  -- Flag PRs targeting a non-default branch.
-  if pr and pr.defaultBranch and pr.baseRefName ~= pr.defaultBranch then
-    chunks[#chunks + 1] = { ' | ' }
-    chunks[#chunks + 1] = { ('Target: %s'):format(pr.baseRefName), 'WarningMsg' }
-  end
-  local nc = (feat == 'pr' or feat == 'issue') and notif_chunk(repo, id)
-  if nc then
-    chunks[#chunks + 1] = { ' | ' }
-    chunks[#chunks + 1] = nc
-  end
-  if pr then
-    chunks[#chunks + 1] = { (' | %s'):format(pr.title) }
-  end
-  for _, win in ipairs(wins) do
-    util.show_winbar(win, chunks)
-  end
-end
-
 --- Implements `:Guh`. Also provides an overload for programmatic callers.
 ---
 --- Shows...
@@ -334,17 +288,6 @@ function M.show_file()
   end)
 end
 
---- Gets the status emoji for a CI job.
---- @param job CIJob
-local function ci_icon(job)
-  if not job.conclusion then
-    return '⏳' -- No `conclusion` until job finishes (still-running / in-progress).
-  elseif job.conclusion == 'success' or job.conclusion == 'neutral' or job.conclusion == 'skipped' then
-    return '✅'
-  end
-  return '❌'
-end
-
 --- Renders `logs` into a `prlogs/…` terminal-buf, or does nothing if already rendered (non-empty).
 local function render_ci_log(buf, logs)
   if not util.buf_empty(buf) then
@@ -367,11 +310,7 @@ local function show_ci_log(job, pr_id, repo)
   -- Key the bufname by `job.databaseId` to disambiguate (multiple logs per PR).
   -- XXX: store pr-id in `b:guh.id` for refresh/actions.
   local buf = state.init_buf('prlogs', true, repo, job.databaseId, { id = pr_id })
-  util.show_winbar(0, {
-    { ('Logs | PR #%s | '):format(pr_id) },
-    { ci_icon(job) },
-    { (' "%s"'):format(job.name) },
-  })
+  state.update_info(buf)
   util.set_default_keymaps(buf)
   if not util.buf_empty(buf) then
     return -- Cache hit (preload or prior open).
@@ -515,10 +454,9 @@ function M.review_pr()
   local function do_action(label)
     local gh_action = label:lower()
     local heading = ('%s PR #%s'):format(label, id)
-    local msg = ('%s | ZZ to submit (ZQ to abort)'):format(heading)
     -- Prefill ":+1:" in the Approve body, so the user can Approve without writing a comment. #64
     local content = label == 'Approve' and { ':+1:' } or { '' }
-    comments.edit_comment('review', id, content, { { msg } }, function(input)
+    comments.edit_comment('review', id, content, { title = heading }, function(input)
       local body = vim.trim(input)
       local done = util.progress(('%s…'):format(heading))
       gh.review_pr(id, repo, gh_action, body, function(ok, stderr)
@@ -642,11 +580,11 @@ function M.merge_pr()
         end
         local text = ('%s\n\n%s'):format(subject, body):gsub('\r', '')
         local content = vim.split(text, '\n', { plain = true })
-        local heading = {
-          { ('[%s]'):format(choice), admin and 'ErrorMsg' or nil },
-          { ' | First line = subject; rest = body | ZZ to merge (ZQ to abort)' },
+        local info = {
+          title = ('[%s]'):format(choice),
+          title_hl = admin and 'ErrorMsg' or nil, -- Flag risky `--admin` merges.
         }
-        comments.edit_comment('merge', id, content, heading, function(input)
+        comments.edit_comment('merge', id, content, info, function(input)
           local subject, body = input:match('^([^\n]*)\n?(.*)$')
           do_merge(choice, subject, vim.trim(body or ''))
         end)
@@ -694,7 +632,6 @@ function M.show_status(focus)
   if state.get_b_key(buf, { 'guh', 'notifications' }) then
     return -- Skip the re-fetch if already loaded.
   end
-  set_winbar(buf, 'status', '', nil, nil)
   util.set_default_keymaps(buf)
   local done = util.progress('Loading notifications...')
   gh.get_user_notifs(buf, function(lines, err)
@@ -746,8 +683,6 @@ function M.show_repo(focus, repo)
   ]]
   )
 
-  set_winbar(buf, 'repo', repo, repo, nil)
-
   util.set_default_keymaps(buf)
   util.run_cmds(buf, { term = true }, {
     {
@@ -788,7 +723,7 @@ function M.set_read()
     end
     done('success')
     state.set_b_key(assert(status_buf), { 'guh', 'notifications', slug }, vim.NIL)
-    set_winbar(buf, feat, id, repo, feat == 'pr' and state.get_pr_data(repo, id) or nil)
+    state.update_info(buf)
   end)
 end
 
@@ -797,7 +732,7 @@ end
 --- @param focus? boolean
 function M.show_issue(id, repo, focus)
   local buf = state.init_buf('issue', focus, repo, id)
-  set_winbar(buf, 'issue', id, repo)
+  state.update_info(buf)
   util.set_default_keymaps(buf)
   util.run_cmds(buf, { term = true }, { gh.cmd(repo, 'issue', 'view', tostring(id), '--comments') })
 end
@@ -929,7 +864,7 @@ function M.show_pr(id, repo, focus)
     vim._with({ buf = buf }, function()
       vim.cmd [[set breakindent nolist filetype=markdown]]
     end)
-    set_winbar(buf, 'pr', id, repo, state.get_pr_data(repo, id))
+    state.update_info(buf)
     vim.api.nvim_buf_call(buf, function()
       vim.cmd([[syntax match GuhWarning /\<\(Checks pending\)/]])
       vim.cmd([[syntax match ErrorMsg /\<\(Checks failing\)/]])
@@ -945,10 +880,10 @@ end
 --- - Diff + comments are presented as 2 'scrollbind' windows.
 ---
 --- @param opts? { id?: integer|string, repo?: string, args?: string }
---- @param on_done? fun(buf: integer, pr_data: PullRequest, n_files: integer, n_viewed_threads: integer)
+--- @param on_done? fun(buf: integer, pr_data: PullRequest)
 function M.load_pr(opts, on_done)
   local _, id, repo = require_pr(opts)
-  local buf = state.init_buf('prdiff', nil, repo, id) -- focus=nil (no display)
+  local buf = state.init_buf('prdiff', nil, repo, id) -- focus=nil: no display.
   util.set_default_keymaps(buf)
 
   -- Show "Loading…" only if we actually fetch.
@@ -982,15 +917,18 @@ function M.load_pr(opts, on_done)
       -- Match offdiff file prefix ("outdated-3271868956:", "outside-3271868956:").
       vim.cmd([[syntax match GuhWarning /\<\(outdated\|outside\)\ze-\d\+:/ containedin=ALL]])
     end)
-    comments.load_pr_comments(id, repo, buf, pr_data, threads, n_files, n_viewed_threads)
+    local comments_buf = comments.load_pr_comments(id, repo, buf, pr_data, threads)
     -- Update `b:guh.pr_data` so the display step doesn't attempt to re-fetch.
     if pr_buf then
       state.set_b_key(pr_buf, { 'guh', 'pr_data', 'n_files' }, n_files)
       state.set_b_key(pr_buf, { 'guh', 'pr_data', 'n_viewed_threads' }, n_viewed_threads)
     end
+    -- Refresh "info" fields on re-render (e.g. after toggling "Viewed", or a Refresh).
+    state.update_info(buf)
+    state.update_info(comments_buf)
     progress('success')
     if on_done then
-      on_done(buf, pr_data, n_files, n_viewed_threads)
+      on_done(buf, pr_data)
     end
   end
 
@@ -1004,7 +942,7 @@ function M.load_pr(opts, on_done)
     try_render()
   end)
 
-  -- 2. Get the current PR diff, unless `gh.get_pr_data` found a cached one (synchronously).
+  -- 2. Get the current PR diff, unless `gh.get_pr_data` (synchronously) found a cached one.
   --    Caching `pr_data.diff_stdout` lets re-renders (e.g. toggling "Viewed") skip this.
   if not diff_stdout then
     util.system(gh.cmd(repo, 'pr', 'diff', tostring(id)), nil, function(r)
@@ -1026,11 +964,11 @@ function M.show_pr_diff(opts)
   -- Fast path: use the cached `b:guh.pr_data`; display without re-fetching.
   local pr_data = state.get_pr_data(repo, id)
   if pr_data and pr_data.n_files and pr_data.n_viewed_threads then
-    return comments.show_pr_comments(id, repo, buf, pr_data, pr_data.n_files, pr_data.n_viewed_threads)
+    return comments.show_pr_comments(id, repo, buf)
   end
 
-  M.load_pr(opts, function(prdiff_buf, pr_data_, n_files, n_viewed_threads)
-    comments.show_pr_comments(id, repo, prdiff_buf, pr_data_, n_files, n_viewed_threads)
+  M.load_pr(opts, function(prdiff_buf)
+    comments.show_pr_comments(id, repo, prdiff_buf)
   end)
 end
 
@@ -1053,13 +991,9 @@ local function new_comment(pr_id, repo, line1, line2)
     end
     local range = info.start_line == info.end_line and tostring(info.end_line)
       or ('%d..%d'):format(info.start_line, info.end_line)
-    local infomsg = {
-      { 'Comment on ' },
-      { ('%s:%s'):format(info.file, range), 'Directory' },
-      { ' | ZZ to send (ZQ to abort)' },
-    }
+    local edit_info = { title = ('Comment on %s:%s'):format(info.file, range) }
     vim.schedule(function()
-      comments.edit_comment('comment', pr_id, { '' }, infomsg, function(input)
+      comments.edit_comment('comment', pr_id, { '' }, edit_info, function(input)
         local progress = util.new_progress_report('Sending comment...', vim.api.nvim_get_current_buf())
         gh.new_comment(pr, input, info.file, info.start_line, info.end_line, info.side, repo, function(resp)
           if resp['errors'] == nil then
@@ -1275,7 +1209,7 @@ function M.ci_logs_pick(opts)
     vim.ui.select(jobs, {
       prompt = ('CI jobs for PR #%s'):format(id),
       format_item = function(j)
-        return ('%s %s'):format(ci_icon(j), j.name)
+        return ('%s %s'):format(gh.ci_icon(j), j.name)
       end,
     }, function(picked)
       if picked then

--- a/lua/guh/pr.lua
+++ b/lua/guh/pr.lua
@@ -353,7 +353,6 @@ local function render_ci_log(buf, logs)
   local chan = vim.api.nvim_open_term(buf, {})
   vim.api.nvim_chan_send(chan, logs)
   vim.fn.chanclose(chan)
-  util.set_default_keymaps(buf)
 end
 
 --- Shows a `prlogs/…` buffer. Fetches the logs unless the buf is already rendered (= non-empty).
@@ -373,6 +372,7 @@ local function show_ci_log(job, pr_id, repo)
     { ci_icon(job) },
     { (' "%s"'):format(job.name) },
   })
+  util.set_default_keymaps(buf)
   if not util.buf_empty(buf) then
     return -- Cache hit (preload or prior open).
   end

--- a/lua/guh/state.lua
+++ b/lua/guh/state.lua
@@ -32,6 +32,20 @@ local bufs = {
   status = {},
 }
 
+-- UI-related `b:guh` fields (for 'winbar').
+local info_fields = {
+  branch = '', -- Non-default base branch to flag (pr).
+  n_files = 0,
+  n_viewed = 0,
+  n_viewed_threads = 0,
+  n_visible_threads = 0,
+  status = '', -- PR state label, or CI job icon (prlogs).
+  status_hl = '',
+  title = '', -- PR title, edit prompt, or CI job name (prlogs).
+  title_hl = '',
+  unread = '',
+}
+
 --- Canonical `bufs[feat][?]` lookup key for a (repo, id) pair.
 local function get_key(repo, id)
   return repo and ('%s/%s'):format(repo, id) or tostring(id)
@@ -57,6 +71,8 @@ function M.get_buf(feat, repo, id, create)
   -- We use buffers as "storage" => we get Vim's "lifecycle" for free.
   -- Explicitly set this even though nvim_create_buf (scratch) sets it implicitly.
   vim.bo[b].bufhidden = 'hide'
+  -- Init `info_fields` defaults once, so the 'winbar' expr can assume the keys exist.
+  vim.b[b].guh = vim.deepcopy(info_fields)
   bufs[feat][key] = b
   assert(type(b) == 'number')
   return b
@@ -231,9 +247,6 @@ function M.init_buf(feat, focus, repo, id, bufstate)
   bufstate = bufstate or {}
   local key = get_key(repo, id)
   local buf = assert(M.get_buf(feat, repo, id))
-  if focus ~= nil then
-    show_buf(buf, focus)
-  end
   if bufstate.id == nil then
     bufstate.id = id == 'all' and 0 or assert(vim._tointeger(id))
   end
@@ -246,8 +259,14 @@ function M.init_buf(feat, focus, repo, id, bufstate)
   -- XXX: Stash the key so anything (e.g. `util.run_cmds()`) can rebuild the `guh://…` URL,
   -- even for "global" (non-repo-specific) buffers like `guh://status`.
   bufstate.bufkey = key
+
+  -- Init `b:guh` + buf name BEFORE show_buf(), so the BufWinEnter handler (which sets 'winbar') has an initialized buf.
+  -- (Note: `info_fields` defaults were seeded at buffer-creation by `get_buf`.)
   set_b_guh(buf, bufstate)
   M.set_buf_name(buf, feat, key)
+  if focus ~= nil then
+    show_buf(buf, focus)
+  end
   return buf, key
 end
 
@@ -308,6 +327,62 @@ function M.set_buf_name(buf, feat, key)
   if prev_altbuf > 0 and prev_altbuf ~= buf and vim.api.nvim_buf_is_valid(prev_altbuf) then
     vim.fn.setreg('#', prev_altbuf)
   end
+end
+
+--- True if the PR/issue slug is in the (status buffer's) unread `notifications` map.
+---
+--- @param repo string "owner/name"
+--- @param id integer|string
+--- @return boolean
+local function has_unread(repo, id)
+  local status_buf = M.get_buf('status', nil, 'all', false)
+  return status_buf ~= nil and M.get_b_key(status_buf, { 'guh', 'notifications', ('%s#%s'):format(repo, id) }) ~= nil
+end
+
+--- Sets various "denormalized" info on b:guh, for use by 'winbar' (but in theory may be useful for other purposes later).
+---
+--- Missing data is stored as empty ("" / 0) rather than deleting, so the 'winbar' expr can assume the fields exist.
+---
+--- @param buf integer
+function M.update_info(buf)
+  local gh = require('guh.gh')
+  local b = M.get_b_guh(buf) --[[@as BufState?]]
+  if not b then
+    return
+  end
+  local pr = b.pr_data or M.get_pr_data(b.repo, b.id)
+  local feat = b.feat
+
+  if feat == 'pr' or feat == 'issue' or feat == 'prdiff' or feat == 'prcomments' then
+    b.unread = has_unread(b.repo, b.id) and 'Unread' or ''
+    if pr then
+      local label = gh.pr_state_label(pr)
+      b.status = label
+      -- Parallel `_hl` field lets the winbar template color `status` dynamically (`%{%…%}` form).
+      b.status_hl = gh.state_hl[label] or ''
+      b.title = pr.title or ''
+      -- Base branch, but only if non-default (flag a non-default merge target).
+      b.branch = (pr.defaultBranch and pr.baseRefName ~= pr.defaultBranch and pr.baseRefName) or ''
+
+      local n_viewed_threads = pr.n_viewed_threads or 0
+      b.n_files = pr.n_files or 0
+      b.n_viewed = vim.tbl_count(pr.viewed or {})
+      b.n_viewed_threads = n_viewed_threads
+      b.n_visible_threads = (pr.n_threads or 0) - (pr.n_resolved or 0) - n_viewed_threads
+    end
+  elseif feat == 'prlogs' and pr then
+    -- `b:guh.id` is the PR number; the job's `databaseId` is the trailing bufname segment. Reuse the
+    -- shared `status`/`title` slots: CI icon as `status`, job name as `title`.
+    local dbid = tonumber((b.bufkey or ''):match('/(%d+)$'))
+    for _, j in ipairs(pr.ci_jobs or {}) do
+      if j.databaseId == dbid then
+        b.status = gh.ci_icon(j)
+        b.title = j.name
+        break
+      end
+    end
+  end
+  vim.b[buf].guh = b
 end
 
 M.bufs = bufs

--- a/lua/guh/types.lua
+++ b/lua/guh/types.lua
@@ -22,12 +22,24 @@
 --- @class BufState
 --- Buffer-local b:guh dict.
 --- @field chan? integer  Marks a `run_cmds` buf as "loaded". Channel-id (term=true) or a synthetic id (plain buffer).
---- @field jobs? integer[] In-flight jobs for the current `run_cmds` run.
 --- @field feat? Feat Feature name
 --- @field id? integer|string PR or issue number, or commit SHA.
+--- @field jobs? integer[] In-flight jobs for the current `run_cmds` run.
+--- @field notifications? table<string, Notification> Unread notifications on `guh://status` (keyed by slug).
 --- @field pr_data? PullRequest
 --- @field repo? string "owner/name"
---- @field notifications? table<string, Notification> Unread notifications on `guh://status` (keyed by slug).
+---
+--- "Info fields: denormalized values for use by 'winbar' (but possibly other consumers later).
+--- @field branch string Target branch (if non-default).
+--- @field n_files integer Diff file count.
+--- @field n_viewed integer "Viewed" file count.
+--- @field n_viewed_threads integer Unresolved threads hidden in "Viewed" files.
+--- @field n_visible_threads integer Unresolved threads visible in the diff.
+--- @field status string PR status label ("Open"/"Draft"/…), or CI job icon (prlogs).
+--- @field status_hl string Highlight group for `status`.
+--- @field title string Feat-specific title.
+--- @field title_hl string Highlight group for `title`.
+--- @field unread string "Unread" when the notification is unread.
 
 --- @class Comment
 --- @field body string

--- a/lua/guh/util.lua
+++ b/lua/guh/util.lua
@@ -483,7 +483,7 @@ function M.run_cmds(buf, opts, cmds, on_done)
 
       if debug then
         -- Append a timing report.
-        local report = { '', '## timing' }
+        local report = { '', '## Timing' }
         for i, cmd in ipairs(cmds) do
           local cmd_str = type(cmd) == 'table' and table.concat(cmd, ' '):gsub('%s+', ' ')
             or ('<lua %s:%d>'):format(
@@ -600,34 +600,6 @@ function M.run_cmds(buf, opts, cmds, on_done)
     -- Store job-ids in case a later `run_cmds` invocation forces a re-request.
     state.set_b_key(buf, { 'guh', 'jobs' }, jobs)
   end)
-end
-
---- Sets the window-local 'winbar' to a list of `{text, hl_group?}` chunks.
----
---- Pass `chunks=nil` to clear/disable.
----
---- @param win integer
---- @param chunks? [string, string?][] List of `{text, hl_group}` pairs, or nil to disable the winbar.
-function M.show_winbar(win, chunks)
-  if not vim.api.nvim_win_is_valid(win) then
-    return
-  end
-  if not chunks then
-    vim.wo[win].winbar = ''
-    return
-  end
-  local parts = {}
-  for i, ck in ipairs(chunks) do
-    local text, hl = ck[1]:gsub('%%', '%%%%'), ck[2] -- escape `%` for statusline syntax
-    assert(hl == nil or type(hl) == 'string', 'show_winbar: hl_group must be a string')
-    -- Example: ({'foo', 'Comment'}) -> "%#Comment#foo%*"
-    table.insert(parts, hl and ('%%#%s#%s%%*'):format(hl, text) or text)
-    -- After the first chunk insert `%<` so the title is preserved and truncation (">" marker) cuts from there.
-    if i == 1 then
-      table.insert(parts, '%<')
-    end
-  end
-  vim.wo[win].winbar = table.concat(parts)
 end
 
 return M

--- a/plugin/guh.lua
+++ b/plugin/guh.lua
@@ -20,6 +20,37 @@ vim.api.nvim_create_autocmd('BufReadCmd', {
   end,
 })
 
+-- Define a fixed 'winbar' for each "feat". `%{b:guh.…}` segments read `b:guh` fields directly. `%{…}` is Vimscript = no marshalling.
+--
+-- - Dynamic groups (state/title color) use the `%{%…%}` form (note: an empty group `%##` is harmless).
+-- - Separators: only `title` is preceded by a "|".
+local status = [[%{%'%#' .. b:guh.status_hl .. '#' .. b:guh.status .. '%*'%}]]
+local winbar = {
+  issue = [[ISSUE #%{b:guh.id}%( %#WarningMsg#%{b:guh.unread}%*%)]],
+  pr = [[PR #%{b:guh.id} ]]
+    .. status
+    .. [[%( %#WarningMsg#%{b:guh.unread}%*%)%( %#WarningMsg#Target: %{b:guh.branch}%*%) | %{b:guh.title}%<]],
+  prcomments = [[PR COMMENTS | Unresolved: %{b:guh.n_visible_threads} | Unresolved in %#@markup.italic#Viewed%*: %{b:guh.n_viewed_threads}%<]],
+  prdiff = [[PR DIFF | Files: %{b:guh.n_files} (%#@markup.italic#Viewed%*: %{b:guh.n_viewed}) | Unresolved: %{b:guh.n_visible_threads}%<]],
+  prlogs = [[LOGS | PR #%{b:guh.id} | ]] .. status .. [[ %{b:guh.title}%<]],
+  repo = [[REPO %{b:guh.repo}]],
+  status = [[STATUS]],
+}
+-- Edit feats: the (optionally colored) `title` prompt + per-feat help hint.
+local title = [[%{%'%#' .. b:guh.title_hl .. '#' .. b:guh.title .. '%*'%}%<]]
+winbar.comment = title .. [[ | ZZ to save (ZQ to abort)]]
+winbar.merge = title .. [[ | First line = subject; rest = body | ZZ to merge (ZQ to abort)]]
+winbar.review = title .. [[ | ZZ to submit (ZQ to abort)]]
+
+-- Every guh:// window gets a 'winbar'.
+vim.api.nvim_create_autocmd('BufWinEnter', {
+  pattern = 'guh://*',
+  group = group,
+  callback = function()
+    vim.wo.winbar = winbar[(vim.b.guh or {}).feat] or ''
+  end,
+})
+
 -- :syncbind the prdiff/prcomments windows.
 vim.api.nvim_create_autocmd({ 'WinEnter', 'WinResized' }, {
   pattern = [[guh://[^/]\+/[^/]\+/{prdiff,prcomments}/*]],

--- a/test/gh_spec.lua
+++ b/test/gh_spec.lua
@@ -676,7 +676,7 @@ describe(':Guh', function()
       timeout = 10000,
       attr_ids = {}, -- Don't care about colors.
       grid = [[
-        {MATCH:PR diff.*}│{MATCH:PR comments.*}|
+        {MATCH:PR DIFF.*}│{MATCH:PR COMMENTS.*}|
         diff --git {MATCH:a/.* b/.*}│^{MATCH:.*}|
         index {MATCH:.*}|
         --- {MATCH:.*}|


### PR DESCRIPTION
Leverage the benefits of 'statusline'-style options: define 'winbar' as
a template which pulls from b:guh state, instead of actively redefining
it over and over. Nvim decides when to rerender it.

This also opens the door for users to define (or disable) the Guh 'winbar'.
